### PR TITLE
update bg-color switch component

### DIFF
--- a/src/components/Switch/index.module.css
+++ b/src/components/Switch/index.module.css
@@ -22,5 +22,5 @@
 }
 
 .selected {
-  @apply bg-white text-[--switch-scheme];
+  @apply text-white bg-[--switch-scheme];
 }


### PR DESCRIPTION
The switch component color was inverted from white to primary. 

<img width="780" alt="Screenshot 2024-02-22 at 13 18 19" src="https://github.com/deptagency-dar/dept-central-lib-client/assets/66892573/a7df9f59-846a-4e78-b1e3-03876477a008">
