### PR TITLE
feat(Avatar): add imageWidth prop to Avatar component

### DIFF
--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -35,6 +35,7 @@ interface User {
 | status      | 'online' | 'company' | 'verified'                                       | Specifies the avatar status.               | -             |
 | type        | 'normal' | 'compact' | 'image'                                          | Specifies the component type.              | "normal"      |
 | className   | string                                                                  | Custom CSS className.                      | ""            |
+| imageWidth  | string                                                                  | Specifies the image width.                 | "63px"        |
 | onLogout    | () => void                                                              | Logout action.                             | -             |
 
 
@@ -61,6 +62,9 @@ const user = {
 
 // Display status
 <Avatar user={user} status="online" type="compact" />
+
+// Specify image width
+<Avatar user={user} status="online" type="compact" width="40px"/>
 ```
 
 ## Go main README

--- a/src/components/Avatar/index.spec.tsx
+++ b/src/components/Avatar/index.spec.tsx
@@ -21,6 +21,16 @@ describe('Avatar component', () => {
     expect(queryByText('Log out')).not.toBeInTheDocument()
   })
 
+  it('applies image width correctly', () => {
+    const width = '40px';
+    const { getByAltText } = render(<Avatar user={user} imageWidth={width} />)
+
+    const image = getByAltText('Avatar') as HTMLImageElement
+    expect(image).toBeInTheDocument()
+    expect(image.src).toEqual('https://example.com/some-image.png')
+    expect(image.className).toEqual(`rounded-full w-[${width}]`)
+  })
+
   describe('"image" type', () => {
     it('renders the image only', () => {
       const { getByAltText, queryByText } = render(

--- a/src/components/Avatar/index.stories.tsx
+++ b/src/components/Avatar/index.stories.tsx
@@ -47,6 +47,14 @@ export default {
         type: { summary: 'User' },
       },
     },
+    imageWidth: {
+      control: 'text',
+      description: 'Width of the avatar image',
+      table: {
+        defaultValue: { summary: '63px' },
+        type: { summary: 'string' },
+      },
+    },
     onLogout: {
       description: 'Event triggered when the checkbox changes its state.',
       action: 'clicked',
@@ -64,6 +72,7 @@ export const Default: Story = {
   args: {
     type: 'normal',
     user,
+    imageWidth: '63px',
     onLogout: () => alert('Logging user out'),
   },
 }
@@ -99,6 +108,23 @@ export const NormalWithLogoutAction: Story = {
   args: {
     ...Default.args,
     onLogout: () => alert('Logging user out'),
+  }
+}
+
+/**
+ * With **normal** type (with imageWidth property)
+ */
+export const NormalWithImageWidth: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `<Avatar user={user} type="normal" imageWidth="40px" />`,
+      },
+    },
+  },
+  args: {
+    ...Default.args,
+    imageWidth: '40px'
   }
 }
 

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -7,12 +7,12 @@ interface User {
 }
 
 type TAvatar = 'normal' | 'compact' | 'image'
-
 type TProps = {
   user: Partial<User>
   status?: 'online' | 'company' | 'verified'
   type?: TAvatar
   className?: string
+  imageWidth?: string
   onLogout?: () => void
 }
 
@@ -21,6 +21,7 @@ export const Avatar: React.FC<TProps> = ({
   status,
   type = 'normal',
   className = '',
+  imageWidth = '63px',
   onLogout,
 }) => {
   function handleLogout(e: React.MouseEvent<HTMLAnchorElement>) {
@@ -55,7 +56,7 @@ export const Avatar: React.FC<TProps> = ({
     return (
       <div className="flex flex-col items-center relative">
         <img
-          className="rounded-full w-[63px]"
+          className={`rounded-full w-[${imageWidth}]`}
           referrerPolicy="no-referrer"
           src={user.image || undefined}
           alt="Avatar"


### PR DESCRIPTION
-Add inputWidth property (default 63px) to customize image size:
Example: 
`<Avatar user={user} type="normal" imageWidth="40px" />`

<img width="339" alt="Screenshot 2024-11-01 at 17 33 17" src="https://github.com/user-attachments/assets/ec94023a-c7d4-469c-8a5f-ebc2d83fef98">
