### PR TITLE
fix: remove hover effect for not clickable rows in Table component

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -60,8 +60,8 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(
                 key={`tr-item-${index}`}
                 {...(onClick && { onClick })}
                 className={cn(
-                  'border-b border-b-grayscale-200 hover:bg-primary-50 transition-colors',
-                  onClick && 'cursor-pointer',
+                  'border-b border-b-grayscale-200 transition-colors',
+                  onClick && 'cursor-pointer hover:bg-primary-50',
                   className,
                 )}
               >


### PR DESCRIPTION
<img width="979" height="265" alt="Screenshot 2025-10-15 at 12 57 18 PM" src="https://github.com/user-attachments/assets/7fd76dd8-b353-4b6d-a72e-312b7d2afeb3" />
<img width="941" height="254" alt="Screenshot 2025-10-15 at 12 57 14 PM" src="https://github.com/user-attachments/assets/d4a8ed15-ea1b-48ed-9951-2cf155b33180" />
